### PR TITLE
Improved waterfall display

### DIFF
--- a/config_webrx.py
+++ b/config_webrx.py
@@ -69,7 +69,8 @@ sdrhu_public_listing = False
 # ==== DSP/RX settings ====
 dsp_plugin="csdr"
 fft_fps=9
-fft_size=4096
+fft_size=16384  # averaging only works on fft_size=16384 for some reason
+fft_averages=50
 samp_rate = 250000
 
 center_freq = 145525000
@@ -146,9 +147,9 @@ iq_server_port = 4951 #TCP port for ncat to listen on. It will send I/Q data ove
 
 #access_log = "~/openwebrx_access.log"
 
-waterfall_colors = "[0x000000ff,0x2e6893ff, 0x69a5d0ff, 0x214b69ff, 0x9dc4e0ff,  0xfff775ff, 0xff8a8aff, 0xb20000ff]"
-waterfall_min_level = -115 #in dB
-waterfall_max_level = 0
+waterfall_colors = "[0x000000ff,0x0000ffff,0x00ffffff,0x00ff00ff,0xffff00ff,0xff0000ff,0xff00ffff,0xffffffff]"
+waterfall_min_level = -85 #in dB
+waterfall_max_level = -20
 #A guide is available to help you set these values: https://github.com/simonyiszk/openwebrx/wiki/Calibrating-waterfall-display-levels
 
 #Warning! The settings below are very experimental.

--- a/config_webrx.py
+++ b/config_webrx.py
@@ -69,9 +69,11 @@ sdrhu_public_listing = False
 # ==== DSP/RX settings ====
 dsp_plugin="csdr"
 fft_fps=9
-fft_size=16384  # averaging only works on fft_size=16384 for some reason
-fft_averages=50
+fft_size=4096
+fft_overlap=0.3
 samp_rate = 250000
+
+fft_averages=int(round(1.0 * samp_rate / fft_size / fft_fps / (1.0 - fft_overlap)))
 
 center_freq = 145525000
 rf_gain = 5 #in dB. For an RTL-SDR, rf_gain=0 will set the tuner to auto gain mode, else it will be in manual gain mode.
@@ -148,7 +150,7 @@ iq_server_port = 4951 #TCP port for ncat to listen on. It will send I/Q data ove
 #access_log = "~/openwebrx_access.log"
 
 waterfall_colors = "[0x000000ff,0x0000ffff,0x00ffffff,0x00ff00ff,0xffff00ff,0xff0000ff,0xff00ffff,0xffffffff]"
-waterfall_min_level = -85 #in dB
+waterfall_min_level = -88 #in dB
 waterfall_max_level = -20
 #A guide is available to help you set these values: https://github.com/simonyiszk/openwebrx/wiki/Calibrating-waterfall-display-levels
 

--- a/htdocs/openwebrx.js
+++ b/htdocs/openwebrx.js
@@ -1018,7 +1018,7 @@ function canvas_mousewheel(evt)
 
 
 zoom_max_level_hps=33; //Hz/pixel
-zoom_levels_count=5;
+zoom_levels_count=14;
 
 function get_zoom_coeff_from_hps(hps)
 {
@@ -1040,8 +1040,10 @@ function mkzoomlevels()
 	zoom_levels=[1];
 	maxc=get_zoom_coeff_from_hps(zoom_max_level_hps);
 	if(maxc<1) return;
+	// logarithmic interpolation
+	zoom_ratio = Math.pow(maxc, 1/zoom_levels_count);
 	for(i=1;i<zoom_levels_count;i++)
-		zoom_levels.push(1+(maxc-1)*(i/(zoom_levels_count-1)));
+		zoom_levels.push(Math.pow(zoom_ratio, i));
 }
 
 function zoom_step(out, where, onscreen)

--- a/openwebrx.py
+++ b/openwebrx.py
@@ -287,6 +287,7 @@ def spectrum_thread_function():
 	dsp.set_samp_rate(cfg.samp_rate)
 	dsp.set_fft_size(cfg.fft_size)
 	dsp.set_fft_fps(cfg.fft_fps)
+	dsp.set_fft_averages(cfg.fft_averages)
 	dsp.set_fft_compression(cfg.fft_compression)
 	dsp.set_format_conversion(cfg.format_conversion)
 	apply_csdr_cfg_to_dsp(dsp)

--- a/plugins/dsp/csdr/plugin.py
+++ b/plugins/dsp/csdr/plugin.py
@@ -59,8 +59,11 @@ class dsp_plugin:
 		if self.csdr_through: any_chain_base+="csdr through | "
 		any_chain_base+=self.format_conversion+(" | " if  self.format_conversion!="" else "") ##"csdr flowcontrol {flowcontrol} auto 1.5 10 | "
 		if which == "fft":
-			#fft_chain_base = any_chain_base+"csdr fft_cc {fft_size} {fft_block_size} | csdr logpower_cf -70 | csdr fft_exchange_sides_ff {fft_size}"
-			fft_chain_base = any_chain_base+"csdr fft_cc {fft_size} {fft_block_size} | csdr logaveragepower_cf -70 {fft_size} {fft_averages} | csdr fft_exchange_sides_ff {fft_size}"
+			if self.fft_averages > 1:
+				fft_chain_base = any_chain_base+"csdr fft_cc {fft_size} {fft_block_size} | csdr logaveragepower_cf -70 {fft_size} {fft_averages} | csdr fft_exchange_sides_ff {fft_size}"
+			else:
+				fft_chain_base = any_chain_base+"csdr fft_cc {fft_size} {fft_block_size} | csdr logpower_cf -70 | csdr fft_exchange_sides_ff {fft_size}"
+
 			if self.fft_compression=="adpcm":
 				return fft_chain_base+" | csdr compress_fft_adpcm_f_u8 {fft_size}"
 			else:

--- a/plugins/dsp/csdr/plugin.py
+++ b/plugins/dsp/csdr/plugin.py
@@ -51,6 +51,7 @@ class dsp_plugin:
 		self.csdr_print_bufsizes = False
 		self.csdr_through = False
 		self.squelch_level = 0
+		self.fft_averages = 50
 
 	def chain(self,which):
 		any_chain_base="ncat -v 127.0.0.1 {nc_port} | "
@@ -58,7 +59,8 @@ class dsp_plugin:
 		if self.csdr_through: any_chain_base+="csdr through | "
 		any_chain_base+=self.format_conversion+(" | " if  self.format_conversion!="" else "") ##"csdr flowcontrol {flowcontrol} auto 1.5 10 | "
 		if which == "fft":
-			fft_chain_base = any_chain_base+"csdr fft_cc {fft_size} {fft_block_size} | csdr logpower_cf -70 | csdr fft_exchange_sides_ff {fft_size}"
+			#fft_chain_base = any_chain_base+"csdr fft_cc {fft_size} {fft_block_size} | csdr logpower_cf -70 | csdr fft_exchange_sides_ff {fft_size}"
+			fft_chain_base = any_chain_base+"csdr fft_cc {fft_size} {fft_block_size} | csdr logaveragepower_cf -70 {fft_size} {fft_averages} | csdr fft_exchange_sides_ff {fft_size}"
 			if self.fft_compression=="adpcm":
 				return fft_chain_base+" | csdr compress_fft_adpcm_f_u8 {fft_size}"
 			else:
@@ -117,8 +119,12 @@ class dsp_plugin:
 		#to change this, restart is required
 		self.fft_fps=fft_fps
 
+	def set_fft_averages(self,fft_averages):
+		#to change this, restart is required
+		self.fft_averages=fft_averages
+
 	def fft_block_size(self):
-		return self.samp_rate/self.fft_fps
+		return self.samp_rate/self.fft_fps/self.fft_averages
 
 	def set_format_conversion(self,format_conversion):
 		self.format_conversion=format_conversion
@@ -181,7 +187,7 @@ class dsp_plugin:
 
 		#run the command
 		command=command_base.format( bpf_pipe=self.bpf_pipe, shift_pipe=self.shift_pipe, decimation=self.decimation, \
-			last_decimation=self.last_decimation, fft_size=self.fft_size, fft_block_size=self.fft_block_size(), \
+			last_decimation=self.last_decimation, fft_size=self.fft_size, fft_block_size=self.fft_block_size(), fft_averages=self.fft_averages, \
 			bpf_transition_bw=float(self.bpf_transition_bw)/self.if_samp_rate(), ddc_transition_bw=self.ddc_transition_bw(), \
 			flowcontrol=int(self.samp_rate*2), start_bufsize=self.base_bufsize*self.decimation, nc_port=self.nc_port, \
 			squelch_pipe=self.squelch_pipe, smeter_pipe=self.smeter_pipe )


### PR DESCRIPTION
I found it was difficult to see weak signals in waterfall display of openwebrx. This could be improved by using slightly overlapping FFT windows and averaging power from multiple FFTs for each waterfall line. This helps improve sensitivity of the waterfall especially when using a high sampling rate and a relatively low fft_fps. Additionally, I changed the default waterfall palette to try to further improve its contrast and make weak signals easier to see.

I've also created a pull request to csdr to implement these averaged FFTs.