### PR TITLE
Support for receivers providing real signal

### DIFF
--- a/config_webrx.py
+++ b/config_webrx.py
@@ -70,7 +70,8 @@ sdrhu_public_listing = False
 dsp_plugin="csdr"
 fft_fps=9
 fft_size=4096
-fft_voverlap_factor=0.3 # How much successive FFT windows overlap in time domain (zero or negative for no overlap)
+fft_enable_average = True  # Set to False if you want to save CPU time
+fft_voverlap_factor=0.3 # How much successive averaged FFT windows overlap in time domain (zero for no overlap, negative to skip samples between FFTs)
 samp_rate = 250000
 center_freq = 145525000
 rf_gain = 5 #in dB. For an RTL-SDR, rf_gain=0 will set the tuner to auto gain mode, else it will be in manual gain mode.

--- a/openwebrx.py
+++ b/openwebrx.py
@@ -287,7 +287,16 @@ def spectrum_thread_function():
 	dsp.set_samp_rate(cfg.samp_rate)
 	dsp.set_fft_size(cfg.fft_size)
 	dsp.set_fft_fps(cfg.fft_fps)
-	dsp.set_fft_averages(int(round(1.0 * cfg.samp_rate / cfg.fft_size / cfg.fft_fps / (1.0 - cfg.fft_voverlap_factor))) if cfg.fft_voverlap_factor>0 else 0)
+	if cfg.fft_enable_average:
+		# number of input samples for fft_fc is fft_size*2, make overlap fraction and fft_fps work correctly in that case:
+		fft_in_size = (cfg.fft_size*2) if cfg.real_input else cfg.fft_size
+		fft_averages = int(round(1.0 * cfg.samp_rate / fft_in_size / cfg.fft_fps / (1.0 - cfg.fft_voverlap_factor)))
+		if fft_averages <= 1:
+			# averaging not needed, disable it
+			fft_averages = 0
+	else:
+		fft_averages = 0
+	dsp.set_fft_averages(fft_averages)
 	dsp.set_fft_compression(cfg.fft_compression)
 	dsp.set_format_conversion(cfg.format_conversion)
 	dsp.set_real_input(cfg.real_input)

--- a/plugins/dsp/csdr/plugin.py
+++ b/plugins/dsp/csdr/plugin.py
@@ -63,7 +63,7 @@ class dsp_plugin:
 			fft_chain_base = any_chain_base + "csdr " + \
 			("fft_fc" if self.real_input else "fft_cc") + \
 			" {fft_size} {fft_block_size} | " + \
-			("csdr logpower_cf -70 | " if self.fft_averages == 0 else "csdr logaveragepower_cf -70 {fft_size} {fft_averages}")
+			("csdr logpower_cf -70" if self.fft_averages == 0 else "csdr logaveragepower_cf -70 {fft_size} {fft_averages}")
 
 			if not self.real_input:
 				fft_chain_base += " | csdr fft_exchange_sides_ff {fft_size}"


### PR DESCRIPTION
OpenWebRX currently seems to support only receivers that provide a complex I/Q signal. This pull request adds support for receivers that output a real signal, such as those using a single ADC to directly sample an RF or IF signal.

Another small change: setting fft_voverlap_factor to zero no longer disables averaging, as I think zero or negative overlap is something one might want to do even with averaging still enabled. I added a separate fft_enable_average option to make it more clear.