### PR TITLE
added device_id parameter on start_rtl_command

### DIFF
--- a/config_webrx.py
+++ b/config_webrx.py
@@ -75,6 +75,7 @@ samp_rate = 250000
 center_freq = 145525000
 rf_gain = 5 #in dB. For an RTL-SDR, rf_gain=0 will set the tuner to auto gain mode, else it will be in manual gain mode.
 ppm = 0
+device_id = 0
 
 audio_compression="adpcm" #valid values: "adpcm", "none"
 fft_compression="adpcm" #valid values: "adpcm", "none"
@@ -91,7 +92,7 @@ start_rtl_thread=True
 
 # >> RTL-SDR via rtl_sdr
 
-start_rtl_command="rtl_sdr -s {samp_rate} -f {center_freq} -p {ppm} -g {rf_gain} -".format(rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate, ppm=ppm)
+start_rtl_command="rtl_sdr -d {device_id} -s {samp_rate} -f {center_freq} -p {ppm} -g {rf_gain} -".format(device_id=device_id, rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate, ppm=ppm)
 format_conversion="csdr convert_u8_f"
 
 #start_rtl_command="hackrf_transfer -s {samp_rate} -f {center_freq} -g {rf_gain} -l16 -a0 -q -r-".format(rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate, ppm=ppm)


### PR DESCRIPTION
added device_id parameter on start_rtl_command for using more than one openwebrx server and/or rtlsdr dongles.