### PR TITLE
Update openwebrx.js

### DIFF
--- a/htdocs/openwebrx.js
+++ b/htdocs/openwebrx.js
@@ -1634,10 +1634,16 @@ String.prototype.startswith=function(str){ return this.indexOf(str) == 0; }; //h
 
 function open_websocket()
 {
+	
+	var webSocketProtocol = "ws";
+	if (window.location.protocol === "https:") {
+		webSocketProtocol = "wss";
+	}
+	
 	//if(ws_url.startswith("ws://localhost:")&&window.location.hostname!="127.0.0.1"&&window.location.hostname!="localhost")
 	//{
 		//divlog("Server administrator should set <em>server_hostname</em> correctly, because it is left as <em>\"localhost\"</em>. Now guessing hostname from page URL.",1);
-		ws_url="ws://"+(window.location.origin.split("://")[1])+"/ws/"; //guess automatically -> now default behaviour
+		ws_url=webSocketProtocol+"://"+(window.location.origin.split("://")[1])+"/ws/"; //guess automatically -> now default behaviour
 	//}
 	if (!("WebSocket" in window))
 		divlog("Your browser does not support WebSocket, which is required for WebRX to run. Please upgrade to a HTML5 compatible browser.");


### PR DESCRIPTION
OpenWebRX cannot currently be used via https proxies (similar to apache). Added conditional switch to ws > wss.

Note: OpenWebRX backend doesn't support wss (or https) out of the box. This is purely for those using proxies.