### PR TITLE
Fix HTTPS problem

### DIFF
--- a/htdocs/openwebrx.js
+++ b/htdocs/openwebrx.js
@@ -1634,10 +1634,15 @@ String.prototype.startswith=function(str){ return this.indexOf(str) == 0; }; //h
 
 function open_websocket()
 {
+	var protocol = 'ws';
+	if(window.location.toString().indexOf('https://') == 0){
+		protocol = 'wss';
+	}
+
 	//if(ws_url.startswith("ws://localhost:")&&window.location.hostname!="127.0.0.1"&&window.location.hostname!="localhost")
 	//{
 		//divlog("Server administrator should set <em>server_hostname</em> correctly, because it is left as <em>\"localhost\"</em>. Now guessing hostname from page URL.",1);
-		ws_url="ws://"+(window.location.origin.split("://")[1])+"/ws/"; //guess automatically -> now default behaviour
+		ws_url = protocol + "://"+(window.location.origin.split("://")[1])+"/ws/"; //guess automatically -> now default behaviour
 	//}
 	if (!("WebSocket" in window))
 		divlog("Your browser does not support WebSocket, which is required for WebRX to run. Please upgrade to a HTML5 compatible browser.");


### PR DESCRIPTION
Automatically switch to `wss` if `https` is used (fixes `SecurityError: The operation is insecure`)