### PR TITLE
Config improvements, new sample IQ file

### DIFF
--- a/config_webrx.py
+++ b/config_webrx.py
@@ -70,10 +70,12 @@ sdrhu_public_listing = False
 fft_fps=9
 fft_size=4096 #Should be power of 2
 fft_voverlap_factor=0.3 #If fft_voverlap_factor is above 0, multiple FFTs will be used for creating a line on the diagram.
+waterfall_auto_adjust=False
 
 # samp_rate = 250000
 samp_rate = 2400000
 center_freq = 144250000
+start_mod = "nfm" #nfm, am, lsb, usb, cw
 rf_gain = 5 #in dB. For an RTL-SDR, rf_gain=0 will set the tuner to auto gain mode, else it will be in manual gain mode.
 ppm = 0
 
@@ -103,14 +105,17 @@ Note: if you experience audio underruns while CPU usage is 100%, you can:
 
 # You can use other SDR hardware as well, by giving your own command that outputs the I/Q samples... Some examples of configuration are available here (default is RTL-SDR):
 
-# >> RTL-SDR via rtl_sdr
-start_rtl_command="rtl_sdr -s {samp_rate} -f {center_freq} -p {ppm} -g {rf_gain} -".format(rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate, ppm=ppm)
-format_conversion="csdr convert_u8_f"
+SDR_source = "IQ file"  # use one of: "rtl_sdr" "rx_sdr" "gr-osmosdr" "sound card" "noise source" "IQ file"
 
-#lna_gain=8
-#rf_amp=1
-#start_rtl_command="hackrf_transfer -s {samp_rate} -f {center_freq} -g {rf_gain} -l{lna_gain} -a{rf_amp} -r-".format(rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate, ppm=ppm, rf_amp=rf_amp, lna_gain=lna_gain)
-#format_conversion="csdr convert_s8_f"
+# >> RTL-SDR via rtl_sdr
+if SDR_source == "rtl_sdr":
+    start_rtl_command="rtl_sdr -s {samp_rate} -f {center_freq} -p {ppm} -g {rf_gain} -".format(rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate, ppm=ppm)
+    format_conversion="csdr convert_u8_f"
+    
+    #lna_gain=8
+    #rf_amp=1
+    #start_rtl_command="hackrf_transfer -s {samp_rate} -f {center_freq} -g {rf_gain} -l{lna_gain} -a{rf_amp} -r-".format(rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate, ppm=ppm, rf_amp=rf_amp, lna_gain=lna_gain)
+    #format_conversion="csdr convert_s8_f"
 """
 To use a HackRF, compile the HackRF host tools from its "stdout" branch:
  git clone https://github.com/mossmann/hackrf/
@@ -127,19 +132,28 @@ To use a HackRF, compile the HackRF host tools from its "stdout" branch:
 
 # >> Sound card SDR (needs ALSA)
 # I did not have the chance to properly test it.
-#samp_rate = 96000
-#start_rtl_command="arecord -f S16_LE -r {samp_rate} -c2 -".format(samp_rate=samp_rate)
-#format_conversion="csdr convert_s16_f | csdr gain_ff 30"
+if SDR_source == "sound card":
+    samp_rate = 96000
+    start_rtl_command="arecord -f S16_LE -r {samp_rate} -c2 -".format(samp_rate=samp_rate)
+    format_conversion="csdr convert_s16_f | csdr gain_ff 30"
 
 # >> /dev/urandom test signal source
-# samp_rate = 2400000
-# start_rtl_command="cat /dev/urandom | (pv -qL `python -c 'print int({samp_rate} * 2.2)'` 2>&1)".format(rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate)
-# format_conversion="csdr convert_u8_f"
+if SDR_source == "noise source":
+    samp_rate = 2400000
+    start_rtl_command="cat /dev/urandom | (pv -qL `python -c 'print int({samp_rate} * 2.2)'` 2>&1)".format(rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate)
+    format_conversion="csdr convert_u8_f"
 
 # >> Pre-recorded raw I/Q file as signal source
-# You will have to correctly specify: samp_rate, center_freq, format_conversion in order to correctly play an I/Q file.
-#start_rtl_command="(while true; do cat my_iq_file.raw; done) | csdr flowcontrol {sr} 20 ".format(sr=samp_rate*2*1.05)
-#format_conversion="csdr convert_u8_f"
+# You will have to correctly specify: samp_rate, center_freq, bytes_per_sample, format_conversion in order to correctly play an I/Q file.
+if SDR_source == "IQ file":
+    samp_rate = 96000
+    center_freq = 7040000
+    bytes_per_sample = 2
+    start_rtl_command="(while true; do cat CQWW_CW_2005.iq16b.fs96k.cf7040.iq; done) | csdr flowcontrol {sr} 20 ".format(sr=samp_rate*bytes_per_sample*2*1.05)
+    #format_conversion="csdr convert_u8_f"
+    format_conversion="csdr convert_s16_f --bigendian | csdr iq_swap_ff"
+    start_mod = "lsb"
+    waterfall_auto_adjust = True
 
 #>> The rx_sdr command works with a variety of SDR harware: RTL-SDR, HackRF, SDRplay, UHD, Airspy, Red Pitaya, audio devices, etc. 
 # It will auto-detect your SDR hardware if the following tools are installed:
@@ -147,12 +161,14 @@ To use a HackRF, compile the HackRF host tools from its "stdout" branch:
 # * the vendor-specific SoapySDR wrapper library, 
 # * and SoapySDR itself.
 # Check out this article on the OpenWebRX Wiki: https://github.com/simonyiszk/openwebrx/wiki/Using-rx_tools-with-OpenWebRX/
-#start_rtl_command="rx_sdr -F CF32 -s {samp_rate} -f {center_freq} -p {ppm} -g {rf_gain} -".format(rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate, ppm=ppm)
-#format_conversion=""
+if SDR_source == "rx_sdr":
+    start_rtl_command="rx_sdr -F CF32 -s {samp_rate} -f {center_freq} -p {ppm} -g {rf_gain} -".format(rf_gain=rf_gain, center_freq=center_freq, samp_rate=samp_rate, ppm=ppm)
+    format_conversion=""
 
 # >> gr-osmosdr signal source using GNU Radio (follow this guide: https://github.com/simonyiszk/openwebrx/wiki/Using-GrOsmoSDR-as-signal-source)
-#start_rtl_command="cat /tmp/osmocom_fifo"
-#format_conversion=""
+if SDR_source == "gr-osmosdr":
+    start_rtl_command="cat /tmp/osmocom_fifo"
+    format_conversion=""
 
 # ==== Misc settings ====
 
@@ -164,7 +180,6 @@ client_audio_buffer_size = 5
 # - decrease the chance of audio underruns
 
 start_freq = center_freq
-start_mod = "nfm" #nfm, am, lsb, usb, cw
 
 iq_server_port = 4951 #TCP port for ncat to listen on. It will send I/Q data over its connections, for internal use in OpenWebRX. It is only accessible from the localhost by default.
 

--- a/htdocs/openwebrx.js
+++ b/htdocs/openwebrx.js
@@ -1249,6 +1249,9 @@ function on_ws_recv(evt)
 						smeter_level=parseFloat(param[1]);
 						setSmeterAbsoluteValue(smeter_level);
 						break;
+					case "waterfall_auto_adjust":
+					   waterfall_measure_minmax_now=(param[1]=="True")? true:false;
+						break;
 				}
 			}
 		/*}

--- a/openwebrx.py
+++ b/openwebrx.py
@@ -457,7 +457,7 @@ class WebRXHandler(BaseHTTPRequestHandler):
                         return
                     myclient.ws_started=True
                     #send default parameters
-                    rxws.send(self, "MSG center_freq={0} bandwidth={1} fft_size={2} fft_fps={3} audio_compression={4} fft_compression={5} max_clients={6} setup".format(str(cfg.shown_center_freq),str(cfg.samp_rate),cfg.fft_size,cfg.fft_fps,cfg.audio_compression,cfg.fft_compression,cfg.max_clients))
+                    rxws.send(self, "MSG center_freq={0} bandwidth={1} fft_size={2} fft_fps={3} audio_compression={4} fft_compression={5} max_clients={6} waterfall_auto_adjust={7} setup".format(str(cfg.shown_center_freq),str(cfg.samp_rate),cfg.fft_size,cfg.fft_fps,cfg.audio_compression,cfg.fft_compression,cfg.max_clients,cfg.waterfall_auto_adjust))
 
                     # ========= Initialize DSP =========
                     dsp=csdr.dsp()


### PR DESCRIPTION
1) SDR hardware selection via a single parameter called “SDR_source”.
2) New parameter “waterfall_auto_adjust” allows initial adjustment.
3) Added an example IQ file from the 2005 CQWW CW contest. It’s adds an
additional 4 MB to the 9 MB of the repository, so that needs to be
considered. But it may be useful to future porting efforts.